### PR TITLE
Fix latitude and longitude order in KML

### DIFF
--- a/service/loadPoints.php
+++ b/service/loadPoints.php
@@ -183,7 +183,7 @@ function addItemIntoXml($item, &$xml, $is_private) {
         }
     }
     $xml .= '</ExtendedData>';
-    $xml .= '<Point><coordinates>' . $item['latitude'] . ',' . $item['longitude'] . ',0.0' . '</coordinates></Point>';
+    $xml .= '<Point><coordinates>' . $item['longitude'] . ',' . $item['latitude'] . ',0.0' . '</coordinates></Point>';
 
     $xml .= '</Placemark>';
 }

--- a/service/loadTrack.php
+++ b/service/loadTrack.php
@@ -103,7 +103,7 @@ foreach ($response_array['channel']['items'] as $item) {
 
     $xml .= '</ExtendedData>';
 
-    $xml .= '<Point><coordinates>' . $item['latitude'] . ',' . $item['longitude'] . ',0.0' . '</coordinates></Point>';
+    $xml .= '<Point><coordinates>' . $item['longitude'] . ',' . $item['latitude'] . ',0.0' . '</coordinates></Point>';
     $xml .= '</Placemark>';
 }
 


### PR DESCRIPTION
Был неправильный порядок широты и долготы в KML

https://developers.google.com/kml/documentation/kml_tut?hl=ru

> Four or more tuples, each consisting of floating point values for longitude, latitude, and altitude
